### PR TITLE
fix: fix iPad/mac size, fix minor layout bugs

### DIFF
--- a/Example App/EmojiPicker.xcodeproj/project.pbxproj
+++ b/Example App/EmojiPicker.xcodeproj/project.pbxproj
@@ -359,8 +359,12 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -374,8 +378,12 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Sources/EmojiPicker/Views/EmojiCategoryView/TouchableEmojiCategoryView.swift
+++ b/Sources/EmojiPicker/Views/EmojiCategoryView/TouchableEmojiCategoryView.swift
@@ -53,9 +53,10 @@ final class TouchableEmojiCategoryView: UIView {
     
     // MARK: - Init
     
-    init(delegate: EmojiCategoryViewDelegate,
-         categoryIndex: Int,
-         selectedEmojiCategoryTintColor: UIColor
+    init(
+        delegate: EmojiCategoryViewDelegate,
+        categoryIndex: Int,
+        selectedEmojiCategoryTintColor: UIColor
     ) {
         self.delegate = delegate
         self.categoryIndex = categoryIndex
@@ -66,6 +67,7 @@ final class TouchableEmojiCategoryView: UIView {
         super.init(frame: .zero)
     }
     
+    @available(*, unavailable, message: "init(coder:) has not been implemented")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/EmojiPicker/Views/EmojiPickerView.swift
+++ b/Sources/EmojiPicker/Views/EmojiPickerView.swift
@@ -45,8 +45,15 @@ final class EmojiPickerView: UIView {
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         collectionView.backgroundColor = .clear
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.register(EmojiCollectionViewCell.self, forCellWithReuseIdentifier: EmojiCollectionViewCell.identifier)
-        collectionView.register(EmojiCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: EmojiCollectionViewHeader.identifier)
+        collectionView.register(
+            EmojiCollectionViewCell.self,
+            forCellWithReuseIdentifier: EmojiCollectionViewCell.identifier
+        )
+        collectionView.register(
+            EmojiCollectionViewHeader.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: EmojiCollectionViewHeader.identifier
+        )
         return collectionView
     }()
     
@@ -68,12 +75,23 @@ final class EmojiPickerView: UIView {
     }()
     
     private var categoryViews = [TouchableEmojiCategoryView]()
+    private var selectedCategoryIndex: Int = .zero
     
     /// Describes height for `categoriesStackView`.
     ///
-    /// - Note: The number `0.13` was taken based on the proportion of this element to the width of the EmojiPicker on MacOS.
-    private var categoriesStackViewHeight: CGFloat {
-        return bounds.width * 0.13
+    /// - Note: The number `0.13` was taken based on the proportion of this element to the width of the EmojiPicker on macOS.
+    private var categoriesStackViewHeight: CGFloat { bounds.width * 0.13 }
+    private var categoriesStackHeightConstraint: NSLayoutConstraint?
+  
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupView()
+    }
+  
+    @available(*, unavailable, message: "init(coder:) has not been implemented")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Override
@@ -82,27 +100,31 @@ final class EmojiPickerView: UIView {
         super.draw(rect)
         
         setupCategoryViews()
-        setupView()
     }
     
     /// Passes the index of the selected category to all categoryViews to update the state.
     ///
     /// - Parameter categoryIndex: Selected category index.
     func updateSelectedCategoryIcon(with categoryIndex: Int) {
+        selectedCategoryIndex = categoryIndex
         categoryViews.forEach {
             $0.updateCategoryViewState(selectedCategoryIndex: categoryIndex)
         }
     }
     
     // MARK: - Private Methods
-
     private func setupView() {
         backgroundColor = .popoverBackgroundColor
-        
+      
         addSubview(collectionView)
         addSubview(categoriesStackView)
         addSubview(separatorView)
         
+        let categoriesStackHeightConstraint = categoriesStackView.heightAnchor.constraint(
+          equalToConstant: categoriesStackViewHeight
+        )
+        self.categoriesStackHeightConstraint = categoriesStackHeightConstraint
+      
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -112,7 +134,7 @@ final class EmojiPickerView: UIView {
             categoriesStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             categoriesStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             categoriesStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -safeAreaInsets.bottom),
-            categoriesStackView.heightAnchor.constraint(equalToConstant: categoriesStackViewHeight),
+            categoriesStackHeightConstraint,
             
             separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -122,6 +144,10 @@ final class EmojiPickerView: UIView {
     }
     
     private func setupCategoryViews() {
+        categoriesStackHeightConstraint?.constant = categoriesStackViewHeight
+        categoryViews = []
+        categoriesStackView.subviews.forEach { $0.removeFromSuperview() }
+      
         for categoryIndex in 0...7 {
             let categoryView = TouchableEmojiCategoryView(
                 delegate: self,
@@ -130,7 +156,7 @@ final class EmojiPickerView: UIView {
             )
             
             /// We need to set _selected_ state for the first category (default at the start).
-            categoryView.updateCategoryViewState(selectedCategoryIndex: 0)
+            categoryView.updateCategoryViewState(selectedCategoryIndex: selectedCategoryIndex)
             categoryViews.append(categoryView)
             categoriesStackView.addArrangedSubview(categoryView)
         }

--- a/Sources/EmojiPicker/Views/EmojiPickerViewController.swift
+++ b/Sources/EmojiPicker/Views/EmojiPickerViewController.swift
@@ -170,16 +170,27 @@ public final class EmojiPickerViewController: UIViewController {
     
     /// Sets up preferred content size.
     ///
-    /// - Note: The number `0.16` was taken based on the proportion of height to the width of the EmojiPicker on MacOS.
+    /// - Note: The number `0.16` was taken based on the proportion of height to the width of the EmojiPicker on macOS.
     private func setupPreferredContentSize() {
-        let sideInset: CGFloat = 20
-        let screenWidth: CGFloat = UIScreen.main.nativeBounds.width / UIScreen.main.nativeScale
-        let popoverWidth: CGFloat = screenWidth - (sideInset * 2)
-        let heightProportionToWidth: CGFloat = 1.16
-        
-        preferredContentSize = CGSize(width: popoverWidth,
-                                      height: customHeight ?? popoverWidth * heightProportionToWidth
-        )
+        let size: CGSize = {
+            switch UIDevice.current.userInterfaceIdiom {
+            case .phone:
+                let sideInset: CGFloat = 20
+                let screenWidth: CGFloat = UIScreen.main.nativeBounds.width / UIScreen.main.nativeScale
+                let popoverWidth: CGFloat = screenWidth - (sideInset * 2)
+                // The number 0.16 was taken based on the proportion of height to the width of the EmojiPicker on macOS.
+                let heightProportionToWidth: CGFloat = 1.16
+                return CGSize(
+                    width: popoverWidth,
+                    height: popoverWidth * heightProportionToWidth
+                )
+            default:
+                // macOS size
+                return CGSize(width: 410, height: 460)
+            }
+        }()
+       
+        preferredContentSize = size
     }
     
     private func setupArrowDirections() {


### PR DESCRIPTION
# What was done

* Fixed size for iPad and mac devices, added hardcoded size based on macOS system component
* Fixed a couple of layout issues. Wrong background color on appearance and duplication of categories on color theme switch.

# Implementation details

iPad size issues are straightforward. The goal is to have some size, as in macOS.

The incorrect background was visible on the picker's appearance, which was fixed by moving the layout setup earlier. 
<img src="https://user-images.githubusercontent.com/25247301/214624021-e155bba6-0cba-463b-abad-df63ebac81e3.png" alt="drawing" width="200"/>

Category items were duplicated every time the color theme was changed since `draw(_:)` is being called multiple times. 
Fixed by removing old subviews.
<img src="https://user-images.githubusercontent.com/25247301/214624825-4e64f3be-b4b3-47be-8af0-0bfb823d88b9.png" alt="drawing" width="200"/>

